### PR TITLE
Feature/menu and edge case fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,61 @@ All commands are registered by `setup()`. If a command is not found, check that 
 
 | Command | Description |
 |---|---|
+| `:TmcMenu` | Open the floating command palette (recommended entry point) |
 | `:TmcDashboard` | Open the course selector → exercise dashboard |
-| `:TmcTest` | Run `tmc test` in the current project root |
+| `:TmcTest` | Run `tmc test` in the current exercise directory |
 | `:TmcSubmit` | Submit the current exercise with a live log window |
 | `:TmcDoctor` | Check TMC authentication / connectivity |
 | `:TmcLogin` | Open a terminal split to run `tmc login` |
+
+> **Note:** `:TmcTest` and `:TmcSubmit` require the current buffer to be inside the
+> configured `exercises_dir`. Opening them from an unrelated file shows a warning
+> instead of running the wrong command.
+
+---
+
+## Menu (`:TmcMenu`)
+
+The recommended entry point. Opens a centered floating window:
+
+```
+╭────────────────────────────────────────────────────╮
+│  ⚡ TMC Plugin                                      │
+│  ✓ Connected  •  mooc-programming-25               │
+├────────────────────────────────────────────────────┤
+│                                                    │
+│  Exercises                                         │
+│  ────────────────────────────────────────────────  │
+│  ▶  󰙨  Dashboard   Browse & manage exercises       │
+│     ✓  Test        Run tests in current exercise   │
+│     ↑  Submit      Submit exercise to TMC          │
+│                                                    │
+│  Account                                           │
+│  ────────────────────────────────────────────────  │
+│     󰍋  Login       Sign in to TMC                  │
+│     ✔  Doctor      Check connection & auth         │
+│                                                    │
+├────────────────────────────────────────────────────┤
+│  j/k Navigate   Enter Select   q Close             │
+╰────────────────────────────────────────────────────╯
+```
+
+**Header behaviour:**
+- Course name is detected **instantly** from the current file path — no network call
+- Auth status (`✓ Connected` / `✗ Auth Required`) is checked async and updates in place
+- `✓ Connected` lights up **green**, `✗ Auth Required` lights up **red**
+- When not authenticated, the cursor auto-focuses the **Login** entry
+
+**Navigation:**
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Move selection up/down |
+| `1`–`5` | Jump directly to that item and execute |
+| `<Enter>` | Execute selected command |
+| `q` / `<Esc>` | Close menu |
+
+The menu closes automatically if you navigate to another window (`<C-w>w`, etc.).
 
 ---
 
@@ -172,6 +222,12 @@ require("tmc_plugin").setup({
   bin = vim.fn.expand("~/tmc-cli-rust-x86_64-apple-darwin-v1.1.2"),
 })
 ```
+
+### `Not in a TMC exercise directory`
+
+`:TmcTest` and `:TmcSubmit` check that the current file is inside `exercises_dir`
+before running. If you see this warning, navigate to a file inside your exercise
+directory first, then run the command again.
 
 ### `Exercise not downloaded`
 

--- a/lua/tmc_plugin/README.md
+++ b/lua/tmc_plugin/README.md
@@ -24,6 +24,7 @@ require("tmc_plugin").setup({
 | `config.lua` | Shared config table (`bin`, `exercises_dir`) |
 | `api.lua` | Public API — courses, exercises, test, submit, download, login, doctor |
 | `dashboard.lua` | Interactive exercise dashboard (buffer + keymaps) |
+| `menu.lua` | Floating command palette (`:TmcMenu`) |
 | `system.lua` | Thin async wrapper around `vim.system` |
 | `ui.lua` | Progress bars, virtual text, log windows, notify helper |
 
@@ -48,8 +49,9 @@ require("tmc_plugin").setup({
 
 | Command | API function | Description |
 |---|---|---|
+| `:TmcMenu` | `menu.open()` | Floating command palette |
 | `:TmcDashboard` | `api.open_dashboard()` | Course picker → exercise dashboard |
-| `:TmcTest` | `api.test()` | Run `tmc test` in the current project root |
+| `:TmcTest` | `api.test()` | Run `tmc test` (must be inside `exercises_dir`) |
 | `:TmcSubmit` | `api.submit()` | Submit with a live streaming log window |
 | `:TmcDoctor` | `api.doctor()` | Check TMC auth / connectivity |
 | `:TmcLogin` | `api.login()` | Terminal split for `tmc login` |

--- a/lua/tmc_plugin/init.lua
+++ b/lua/tmc_plugin/init.lua
@@ -10,6 +10,7 @@ function M.setup(opts)
         config.exercises_dir = vim.fn.expand(opts.exercises_dir)
     end
     local commands = {
+        TmcMenu      = "menu",
         TmcDashboard = "open_dashboard",
         TmcTest      = "test",
         TmcSubmit    = "submit",
@@ -18,8 +19,12 @@ function M.setup(opts)
     }
     for cmd_name, api_func in pairs(commands) do
         vim.api.nvim_create_user_command(cmd_name, function()
-            require("tmc_plugin.api")[api_func]()
-        end, {})
+            if cmd_name == "TmcMenu" then
+                require("tmc_plugin.menu").open()
+            else
+                require("tmc_plugin.api")[api_func]()
+            end
+        end, { desc = "TMC: " .. api_func })
     end
 end
 

--- a/lua/tmc_plugin/menu.lua
+++ b/lua/tmc_plugin/menu.lua
@@ -1,0 +1,289 @@
+-- menu.lua
+-- Floating window command palette for the TMC plugin.
+-- No external dependencies — pure Neovim APIs.
+local M = {}
+local config  = require("tmc_plugin.config")
+local system  = require("tmc_plugin.system")
+local _menu_win = nil   -- tracks the single open menu window
+
+local W = 52  -- total window width including the two border chars
+
+-- ─── Box drawing ─────────────────────────────────────────────────────────────
+
+local function inner(text)
+    local iw = W - 2  -- inner width (excludes │ on each side)
+    local dw = vim.api.nvim_strwidth(text)
+    return text .. string.rep(" ", math.max(0, iw - dw))
+end
+
+local function box(text) return "│" .. inner(text) .. "│" end
+local function top()     return "╭" .. string.rep("─", W - 2) .. "╮" end
+local function mid()     return "├" .. string.rep("─", W - 2) .. "┤" end
+local function bot()     return "╰" .. string.rep("─", W - 2) .. "╯" end
+local function sep()     return box("  " .. string.rep("─", W - 6)) end
+
+-- ─── Course detection (instant, no network) ───────────────────────────────────
+
+local function detect_course()
+    local path = vim.fn.expand("%:p")
+    local base = vim.fn.expand(config.exercises_dir)
+    -- Normalise trailing slash
+    if base:sub(-1) == "/" then base = base:sub(1, -2) end
+    if path:sub(1, #base) == base then
+        local rest = path:sub(#base + 2)         -- skip the separator
+        return rest:match("^([^/\\]+)")           -- first directory = course name
+    end
+    return nil
+end
+
+-- ─── Menu items ───────────────────────────────────────────────────────────────
+
+-- type = "group"  → category header + separator
+-- type = "item"   → selectable entry
+-- type = "spacer" → blank line
+local ITEMS = {
+    { type = "group", label = "Exercises" },
+    { type = "item",  icon = "󰙨",  label = "Dashboard",  desc = "Browse & manage exercises",   action = "open_dashboard" },
+    { type = "item",  icon = "✓",  label = "Test",        desc = "Run tests in current exercise", action = "test" },
+    { type = "item",  icon = "↑",  label = "Submit",      desc = "Submit exercise to TMC",       action = "submit" },
+    { type = "spacer" },
+    { type = "group", label = "Account" },
+    { type = "item",  icon = "󰍋",  label = "Login",       desc = "Sign in to TMC",              action = "login" },
+    { type = "item",  icon = "✔",  label = "Doctor",      desc = "Check connection & auth",     action = "doctor" },
+}
+
+-- ─── Buffer content builder ───────────────────────────────────────────────────
+
+-- Returns:
+--   lines      – the full list of strings to put in the buffer
+--   selectables – { line (0-based), action, is_login } for each item entry
+--   group_lines – 0-based line indices of group header rows (for highlighting)
+local function build(auth_status, course)
+    -- Separate the COLOURED indicator from the neutral hint that follows it.
+    -- Line 2 byte layout: │(3) + "  "(2) = indicator starts at byte 5
+    local indicator, hint
+    if auth_status == nil then
+        indicator = "Checking..."
+        hint      = ""
+    elseif auth_status then
+        indicator = "✓ Connected"
+        hint      = course and ("  •  " .. course) or "  •  No exercise detected"
+    else
+        indicator = "✗ Auth Required"
+        hint      = "  —  use Login below"
+    end
+
+    local lines = {
+        top(),                                -- 0
+        box("  ⚡ TMC Plugin"),               -- 1
+        box("  " .. indicator .. hint),       -- 2  ← status line
+        mid(),                                -- 3
+        box(""),                              -- 4
+    }
+
+    local selectables = {}
+    local group_lines = {}
+
+    for _, item in ipairs(ITEMS) do
+        if item.type == "group" then
+            table.insert(group_lines, #lines)
+            table.insert(lines, box("  " .. item.label))
+            table.insert(lines, sep())
+        elseif item.type == "item" then
+            local line_idx = #lines
+            local content = string.format("     %s  %-11s %s",
+                item.icon, item.label, item.desc)
+            table.insert(lines, box(content))
+            table.insert(selectables, {
+                line     = line_idx,
+                action   = item.action,
+                is_login = item.action == "login",
+            })
+        elseif item.type == "spacer" then
+            table.insert(lines, box(""))
+        end
+    end
+
+    table.insert(lines, box(""))
+    table.insert(lines, mid())
+    table.insert(lines, box("  j/k Navigate   Enter Select   q Close"))
+    table.insert(lines, bot())
+
+    -- Return indicator so the caller can compute its byte range for highlighting
+    return lines, selectables, group_lines, indicator
+end
+
+-- ─── Open ─────────────────────────────────────────────────────────────────────
+
+function M.open()
+    -- If a menu is already open, close it first (prevents stacking)
+    if _menu_win and vim.api.nvim_win_is_valid(_menu_win) then
+        vim.api.nvim_win_close(_menu_win, true)
+    end
+
+    -- Ensure highlight groups exist (safe to call repeatedly)
+    vim.api.nvim_set_hl(0, "TmcMenuTitle",    { fg = "#e5c07b", bold = true })
+    vim.api.nvim_set_hl(0, "TmcMenuGroup",    { fg = "#5c6370", italic = true })
+    vim.api.nvim_set_hl(0, "TmcMenuHint",     { fg = "#5c6370" })
+    vim.api.nvim_set_hl(0, "TmcMenuSelected", { fg = "#61afef", bold = true, reverse = true })
+
+    local course     = detect_course()
+    local auth_status = nil   -- nil = still checking
+
+    local lines, selectables, group_lines, indicator = build(auth_status, course)
+
+    -- ── Create buffer ──────────────────────────────────────────────────────
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    for k, v in pairs({ modifiable = false, bufhidden = "wipe", buftype = "nofile" }) do
+        vim.bo[buf][k] = v
+    end
+
+    -- ── Open centered floating window ──────────────────────────────────────
+    local height = #lines
+    local win = vim.api.nvim_open_win(buf, true, {
+        relative = "editor",
+        row      = math.max(0, math.floor((vim.o.lines   - height) / 2)),
+        col      = math.max(0, math.floor((vim.o.columns - W)      / 2)),
+        width    = W,
+        height   = height,
+        style    = "minimal",
+        zindex   = 50,
+    })
+    for k, v in pairs({ wrap = false, number = false, relativenumber = false,
+                         signcolumn = "no", cursorline = false }) do
+        vim.wo[win][k] = v
+    end
+    _menu_win = win  -- register so repeated :TmcMenu calls close the old one
+
+    -- ── Namespaces ─────────────────────────────────────────────────────────
+    local ns_static = vim.api.nvim_create_namespace("tmc_menu_static")
+    local ns_cursor = vim.api.nvim_create_namespace("tmc_menu_cursor")
+
+    -- Byte layout of line 2: │(3 bytes) + "  "(2 bytes) = indicator at byte 5
+    local STATUS_BYTE_START = 5
+
+    local function apply_static_highlights(ind, logged)
+        vim.api.nvim_buf_clear_namespace(buf, ns_static, 0, -1)
+        -- Title line
+        vim.api.nvim_buf_add_highlight(buf, ns_static, "TmcMenuTitle", 1, 0, -1)
+        -- Status indicator — colour ONLY the indicator word, not the course name
+        local hl = (logged == nil)    and "TmcMenuHint"
+                or logged             and "TmcSuccess"
+                or                       "TmcFailure"
+        vim.api.nvim_buf_add_highlight(buf, ns_static, hl,
+            2, STATUS_BYTE_START, STATUS_BYTE_START + #ind)
+        -- Group headers
+        for _, gl in ipairs(group_lines) do
+            vim.api.nvim_buf_add_highlight(buf, ns_static, "TmcMenuGroup", gl, 0, -1)
+        end
+        -- Footer hint
+        vim.api.nvim_buf_add_highlight(buf, ns_static, "TmcMenuHint", #lines - 2, 0, -1)
+    end
+
+    apply_static_highlights(indicator, auth_status)
+
+    -- ── Selection ──────────────────────────────────────────────────────────
+    local selected = 1
+
+    local function render_cursor()
+        vim.api.nvim_buf_clear_namespace(buf, ns_cursor, 0, -1)
+        local s = selectables[selected]
+        if s then
+            vim.api.nvim_buf_add_highlight(buf, ns_cursor, "TmcMenuSelected", s.line, 0, -1)
+        end
+    end
+
+    render_cursor()
+
+    -- ── Actions ────────────────────────────────────────────────────────────
+    local function close()
+        if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+        end
+        _menu_win = nil
+    end
+
+    -- Close the float automatically if the user navigates away (Ctrl-w, etc.)
+    vim.api.nvim_create_autocmd("WinLeave", {
+        buffer   = buf,
+        once     = true,
+        callback = function() vim.schedule(close) end,
+    })
+
+    local function execute()
+        local s = selectables[selected]
+        if not s then return end
+        close()
+        vim.schedule(function() require("tmc_plugin.api")[s.action]() end)
+    end
+
+    -- ── Keymaps ────────────────────────────────────────────────────────────
+    local o = { buffer = buf, noremap = true, silent = true, nowait = true }
+
+    vim.keymap.set("n", "j", function()
+        selected = (selected % #selectables) + 1
+        render_cursor()
+    end, o)
+
+    vim.keymap.set("n", "k", function()
+        selected = ((selected - 2) % #selectables) + 1
+        render_cursor()
+    end, o)
+
+    -- Number shortcuts: 1-6 jump directly to that item and execute
+    for i = 1, #selectables do
+        vim.keymap.set("n", tostring(i), function()
+            selected = i
+            render_cursor()
+            vim.defer_fn(execute, 80)   -- brief flash so user sees selection
+        end, o)
+    end
+
+    vim.keymap.set("n", "<CR>",  execute, o)
+    vim.keymap.set("n", "q",     close,   o)
+    vim.keymap.set("n", "<Esc>", close,   o)
+
+    -- ── Async auth check ───────────────────────────────────────────────────
+    -- Menu opens instantly; status line updates ~1 s later with real result.
+    system.run({ "courses" }, function(obj)
+        local out    = (obj.stdout .. obj.stderr):lower()
+        local logged = obj.code == 0
+            and not out:match("login")
+            and not out:match("error")
+
+        vim.schedule(function()
+            if not vim.api.nvim_buf_is_valid(buf) then return end
+
+            auth_status = logged
+
+            -- Rebuild just line 2 with the updated indicator + hint
+            local new_indicator = logged and "✓ Connected" or "✗ Auth Required"
+            local new_hint      = logged
+                and (course and ("  •  " .. course) or "  •  No exercise detected")
+                or  "  —  use Login below"
+            local new_line = box("  " .. new_indicator .. new_hint)
+
+            vim.bo[buf].modifiable = true
+            vim.api.nvim_buf_set_lines(buf, 2, 3, false, { new_line })
+            vim.bo[buf].modifiable = false
+
+            -- Re-apply highlights with the new indicator text for byte-range calc
+            apply_static_highlights(new_indicator, logged)
+            render_cursor()
+
+            -- Auto-focus Login when not authenticated
+            if not logged then
+                for i, s in ipairs(selectables) do
+                    if s.is_login then
+                        selected = i
+                        render_cursor()
+                        break
+                    end
+                end
+            end
+        end)
+    end)
+end
+
+return M

--- a/lua/tmc_plugin/ui.lua
+++ b/lua/tmc_plugin/ui.lua
@@ -1,5 +1,6 @@
 local M = {}
-local ns_id = vim.api.nvim_create_namespace("tmc_status")
+local ns_id   = vim.api.nvim_create_namespace("tmc_status")
+local _log_buf = nil   -- tracks the single reusable test-output log window
 local theme = { course = "󰉋 ", exercise_pending = "󱎫 ", exercise_done = "󰄬 ", menu = "󰮫 ", default = "• " }
 
 vim.api.nvim_set_hl(0, "TmcSuccess", { fg = "#98c379", bold = true })
@@ -26,6 +27,7 @@ function M.show_menu(items, prompt_text, menu_type, on_select, max_name_len)
 end
 
 function M.show_virtual_status(bufnr, message, is_success)
+    if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then return end
     vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
     vim.api.nvim_buf_set_extmark(bufnr, ns_id, 0, 0, {
         virt_text = { { (is_success and "󰄬 " or "󰅙 ") .. message, is_success and "TmcSuccess" or "TmcFailure" } },
@@ -34,20 +36,42 @@ function M.show_virtual_status(bufnr, message, is_success)
 end
 
 function M.show_log_window(content)
+    -- Reuse a single log window — close the old one before creating a new one
+    if _log_buf and vim.api.nvim_buf_is_valid(_log_buf) then
+        vim.api.nvim_buf_delete(_log_buf, { force = true })
+    end
+    local cleaned = {}
+    for _, line in ipairs(vim.split(content, "\n")) do
+        local s = line
+            :gsub("\x1b%[[%d;]*[A-Za-z]", "")  -- strip ANSI escape sequences
+            :gsub("\r", "")                      -- strip carriage returns
+            :gsub("%s+$", "")                    -- strip trailing whitespace
+        local trimmed = s:gsub("^%s+", "")
+        local is_noise = trimmed:match("^No Auto%-Updates")
+            or trimmed:match("^%d+%%%[")         -- progress bars "0%[░░░]"
+        if not is_noise then
+            table.insert(cleaned, s)
+        end
+    end
     local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(content, "\n"))
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, cleaned)
+    vim.bo[buf].bufhidden = "wipe"
     vim.cmd("botright 12split")
     vim.api.nvim_win_set_buf(0, buf)
-    vim.keymap.set("n", "q", ":close<CR>", { buffer = buf })
+    vim.keymap.set("n", "q", ":close<CR>", { buffer = buf, silent = true })
+    _log_buf = buf
 end
 
 function M.create_live_log_window(title)
+    local t = title or "TMC Log"
     local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { title or "TMC Log", string.rep("=", #(title or "TMC Log")) })
+    -- Use strwidth so the separator matches display width even with multi-byte chars
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false,
+        { t, string.rep("=", vim.api.nvim_strwidth(t)) })
     vim.cmd("botright 12split")
     local win = vim.api.nvim_get_current_win()
     vim.api.nvim_win_set_buf(win, buf)
-    vim.keymap.set("n", "q", ":close<CR>", { buffer = buf })
+    vim.keymap.set("n", "q", ":close<CR>", { buffer = buf, silent = true })
     return buf, win
 end
 


### PR DESCRIPTION
This PR introduces the new `:TmcMenu` floating command palette as the recommended entry point for the plugin, alongside a full audit and fix of 11 edge cases found across [api.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/api.lua:0:0-0:0), [ui.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/ui.lua:0:0-0:0), and [menu.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/menu.lua:0:0-0:0).
---
## New Feature — `:TmcMenu` Command Palette
A centered floating window that surfaces all plugin commands in one place, with no external dependencies.
**What it does:**
- Opens a categorised menu (Exercises / Account) with `j`/`k` navigation and number shortcuts `1`–`5`
- Detects the **current course instantly** from the active file path — no network call
- Checks **auth status asynchronously** (`tmc courses`) and updates the header in place
- `✓ Connected` highlights **green**, `✗ Auth Required` highlights **red** (inline byte-range highlight — only the status word, not the course name)
- **Auto-focuses Login** when not authenticated
- Closes automatically if the user navigates to another window (`<C-w>w`, etc.)
- Prevents stacking — reopening `:TmcMenu` closes the previous float first
---
## Bug Fixes
### [api.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/api.lua:0:0-0:0)
| # | Issue | Fix |
|---|---|---|
| 1 | `login()` crashes with nil concat if `bin` is unset | Use `(config.bin or "tmc")` |
| 2 | `login()` uses `export EDITOR=cat &&` which breaks in fish shell | Changed to `env EDITOR=cat` (works in bash/zsh/fish/sh) |
| 3 | `open_dashboard()` passes empty list to `vim.ui.select` when not logged in | Early return — `get_courses` already notified the user |
| 4 | Course list order is non-deterministic across fetches | `table.sort` results alphabetically before caching |
| 5 | `:TmcTest` runs `tmc test` in any buffer's cwd, causing silent failures | Added `exercises_dir` path guard with a clear warning message |
| 6 | `:TmcSubmit` same issue | Same guard applied |
### [ui.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/ui.lua:0:0-0:0)
| # | Issue | Fix |
|---|---|---|
| 7 | `show_virtual_status()` crashes if the buffer is closed before the async callback fires | Added `nvim_buf_is_valid` guard |
| 8 | Each `:TmcTest` call opens a new 12-line split, accumulating log windows | Single `_log_buf` tracker — old log window is closed before opening a new one |
| 9 | `=` separator in log window uses `#title` (bytes) instead of display width | Changed to `nvim_strwidth` |
### [menu.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/menu.lua:0:0-0:0)
| # | Issue | Fix |
|---|---|---|
| 10 | Pressing `:TmcMenu` multiple times stacks floating windows | Module-level `_menu_win` — reopening closes the previous float first |
| 11 | Floating window stays open if user navigates away with `<C-w>w` | `WinLeave` autocmd calls `close()` automatically |
---
## Documentation
Both [README.md](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/README.md:0:0-0:0) files updated:
- `:TmcMenu` added to the commands table (marked as recommended entry point)
- Full Menu section added with ASCII layout preview, header behaviour, and navigation reference
- [menu.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/menu.lua:0:0-0:0) added to the developer module overview table
- New troubleshooting entry for "Not in a TMC exercise directory"
---
## Files Changed
- [lua/tmc_plugin/menu.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/menu.lua:0:0-0:0) — new file
- [lua/tmc_plugin/api.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/api.lua:0:0-0:0) — 6 fixes
- [lua/tmc_plugin/ui.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/ui.lua:0:0-0:0) — 3 fixes
- [lua/tmc_plugin/init.lua](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/init.lua:0:0-0:0) — registers `:TmcMenu`
- [README.md](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/README.md:0:0-0:0) — updated
- [lua/tmc_plugin/README.md](cci:7://file:///Users/shingikamucheka/projects/tmc_plugin/lua/tmc_plugin/README.md:0:0-0:0) — updated