### PR TITLE
feat: TmcMenu command palette + exercise navigation + 11 edge case fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ All commands are registered by `setup()`. If a command is not found, check that 
 | `:TmcDashboard` | Open the course selector → exercise dashboard |
 | `:TmcTest` | Run `tmc test` in the current exercise directory |
 | `:TmcSubmit` | Submit the current exercise with a live log window |
+| `:TmcNext` | Navigate to the next exercise in the current course |
+| `:TmcPrev` | Navigate to the previous exercise in the current course |
 | `:TmcDoctor` | Check TMC authentication / connectivity |
 | `:TmcLogin` | Open a terminal split to run `tmc login` |
 
@@ -153,9 +155,31 @@ The recommended entry point. Opens a centered floating window:
 
 The menu closes automatically if you navigate to another window (`<C-w>w`, etc.).
 
+## Exercise Navigation (`:TmcNext` / `:TmcPrev`)
+
+Navigate between exercises without leaving Neovim.
+
+```
+:TmcNext   → opens the next exercise in the course
+:TmcPrev   → opens the previous exercise
+```
+
+**Behaviour:**
+
+| Situation | Result |
+|---|---|
+| Inside a downloaded exercise | Opens the first source file of the adjacent exercise |
+| Exercise not downloaded | Confirm dialog: `[d] Download & open` / `[q] Cancel` |
+| At the first exercise, `:TmcPrev` | `"You are at the first exercise of <course>"` |
+| At the last exercise, `:TmcNext` | `"You have reached the end of <course>! 🎉"` |
+| Not inside `exercises_dir` | Warning to open an exercise file first |
+| Dashboard is open | Scrolls to and flashes the new exercise row |
+
+> **Tip:** Run `:TmcDashboard` at least once before using navigation so the
+> exercise list is cached locally.
+
 ---
 
-## Dashboard
 
 `:TmcDashboard` opens a course picker, then renders an exercise list in a vertical split:
 

--- a/lua/tmc_plugin/README.md
+++ b/lua/tmc_plugin/README.md
@@ -53,6 +53,8 @@ require("tmc_plugin").setup({
 | `:TmcDashboard` | `api.open_dashboard()` | Course picker → exercise dashboard |
 | `:TmcTest` | `api.test()` | Run `tmc test` (must be inside `exercises_dir`) |
 | `:TmcSubmit` | `api.submit()` | Submit with a live streaming log window |
+| `:TmcNext` | `api.next()` | Open next exercise, download prompt if needed |
+| `:TmcPrev` | `api.prev()` | Open previous exercise, boundary message at ends |
 | `:TmcDoctor` | `api.doctor()` | Check TMC auth / connectivity |
 | `:TmcLogin` | `api.login()` | Terminal split for `tmc login` |
 
@@ -91,3 +93,20 @@ require("tmc_plugin").setup({
 `api.lua` lazy-requires `dashboard.lua` (via `require("tmc_plugin.dashboard")` inside callbacks).  
 `dashboard.lua` lazy-requires `api.lua` for the same reason.  
 Neither module requires the other at the top level — this is intentional.
+
+---
+
+## Navigation internals
+
+`api.next()` / `api.prev()` are implemented with three local helpers:
+
+| Helper | What it does |
+|---|---|
+| `detect_exercise()` | Parses the current file path into `{ course, name, index, exercises }` |
+| `find_source_file(dir)` | Globs `src/**/*`, skips compiled extensions (`.pyc`, `.class`, etc.) |
+| `navigate_to_exercise(ctx, ex)` | Checks disk, shows `ui.confirm_dialog` if not downloaded, opens file |
+
+`dashboard.scroll_to_exercise(name)` uses a dedicated `NS_NAV` namespace for the  
+flash highlight so it doesn’t disturb the dashboard’s own render highlights.
+
+`ui.confirm_dialog(opts)` is a reusable floating prompt — see `ui.lua` for the opts shape.

--- a/lua/tmc_plugin/init.lua
+++ b/lua/tmc_plugin/init.lua
@@ -16,6 +16,8 @@ function M.setup(opts)
         TmcSubmit    = "submit",
         TmcDoctor    = "doctor",
         TmcLogin     = "login",
+        TmcNext      = "next",
+        TmcPrev      = "prev",
     }
     for cmd_name, api_func in pairs(commands) do
         vim.api.nvim_create_user_command(cmd_name, function()


### PR DESCRIPTION
## Overview

This PR delivers two new features and a comprehensive bug fix pass across the plugin.

---

## New Feature — `:TmcMenu` Command Palette

A centered floating window that surfaces all plugin commands in one place, with no external dependencies.

**What it does:**
- Opens a categorised menu (Exercises / Account) with `j`/`k` navigation and number shortcuts `1`–`5`
- Detects the **current course instantly** from the active file path — no network call
- Checks **auth status asynchronously** (`tmc courses`) and updates the header in place
- `✓ Connected` highlights **green**, `✗ Auth Required` highlights **red** (inline byte-range highlight — only the status word, not the course name)
- **Auto-focuses Login** when not authenticated
- Closes automatically if the user navigates to another window
- Prevents stacking — reopening `:TmcMenu` closes the previous float first

---

## New Feature — `:TmcNext` / `:TmcPrev` Exercise Navigation

Navigate between exercises without leaving Neovim.

| Situation | Result |
|---|---|
| Inside a downloaded exercise | Opens the first source file of the adjacent exercise |
| Exercise not downloaded | Confirm dialog: `[d] Download & open` / `[q] Cancel` |
| At the first exercise, `:TmcPrev` | Informational boundary message |
| At the last exercise, `:TmcNext` | Informational boundary message |
| Dashboard is open | Scrolls to and flashes the new exercise row |

> **Implementation note:** `detect_exercise()` parses the current file path instantly (no network). `find_source_file()` globs `src/**/*` and skips compiled extensions (`.pyc`, `.class`, etc.). `download_exercise()` now accepts an `on_done` callback so the file opens immediately after download completes.

---

## Bug Fixes (11 total)

### `api.lua`
| # | Issue | Fix |
|---|---|---|
| 1 | `login()` crashes with nil concat if `bin` is unset | Use `(config.bin or "tmc")` |
| 2 | `login()` uses `export EDITOR=cat &&` which breaks in fish shell | Changed to `env EDITOR=cat` |
| 3 | `open_dashboard()` passes empty list to `vim.ui.select` when not logged in | Early return |
| 4 | Course list order is non-deterministic across fetches | `table.sort` alphabetically before caching |
| 5 | `:TmcTest` runs in any buffer's cwd, causing silent failures | `exercises_dir` path guard |
| 6 | `:TmcSubmit` same issue | Same guard applied |

### `ui.lua`
| # | Issue | Fix |
|---|---|---|
| 7 | `show_virtual_status()` crashes if buffer closes before async callback | `nvim_buf_is_valid` guard |
| 8 | Each `:TmcTest` call opens a new split, accumulating log windows | Single `_log_buf` tracker |
| 9 | `=` separator uses byte length instead of display width | Changed to `nvim_strwidth` |

### `menu.lua`
| # | Issue | Fix |
|---|---|---|
| 10 | Multiple `:TmcMenu` calls stack floating windows | Module-level `_menu_win` guard |
| 11 | Float stays open on `<C-w>w` | `WinLeave` autocmd closes it automatically |

---

## Files Changed
- `lua/tmc_plugin/menu.lua` — new file (command palette)
- `lua/tmc_plugin/api.lua` — navigation feature + 6 bug fixes
- `lua/tmc_plugin/ui.lua` — `confirm_dialog()` + 3 bug fixes
- `lua/tmc_plugin/dashboard.lua` — `scroll_to_exercise()`
- `lua/tmc_plugin/init.lua` — registers `:TmcMenu`, `:TmcNext`, `:TmcPrev`
- `README.md` — updated with all new commands and sections
- `lua/tmc_plugin/README.md` — updated developer reference