### PR TITLE
feat: Add MOOC.fi Exercise Instructions UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ All commands are registered by `setup()`. If a command is not found, check that 
 | `:TmcSubmit` | Submit the current exercise with a live log window |
 | `:TmcNext` | Navigate to the next exercise in the current course |
 | `:TmcPrev` | Navigate to the previous exercise in the current course |
+| `:TmcInstructions` | Display instructions for the active exercise inside a Neovim split |
 | `:TmcDoctor` | Full diagnostics report — binary, auth, cache, context, config |
 | `:TmcLogin` | Open a terminal split to run `tmc login` |
 

--- a/lua/tmc_plugin/README.md
+++ b/lua/tmc_plugin/README.md
@@ -25,6 +25,7 @@ require("tmc_plugin").setup({
 | `api.lua` | Public API — courses, exercises, test, submit, download, login, doctor |
 | `dashboard.lua` | Interactive exercise dashboard (buffer + keymaps) |
 | `doctor.lua` | Diagnostics report (`:TmcDoctor`) — 7 checks, async updates |
+| `instructions.lua`| Fetches, parses and caches MOOC.fi exercise instructions |
 | `menu.lua` | Floating command palette (`:TmcMenu`) |
 | `system.lua` | Thin async wrapper around `vim.system` |
 | `ui.lua` | Progress bars, virtual text, log windows, notify helper |
@@ -56,6 +57,7 @@ require("tmc_plugin").setup({
 | `:TmcSubmit` | `api.submit()` | Submit with a live streaming log window |
 | `:TmcNext` | `api.next()` | Open next exercise, download prompt if needed |
 | `:TmcPrev` | `api.prev()` | Open previous exercise, boundary message at ends |
+| `:TmcInstructions` | `instructions.fetch_and_show()` | Display instructions for active exercise |
 | `:TmcDoctor` | `doctor.run()` | Full diagnostics report (7 checks) |
 | `:TmcLogin` | `api.login()` | Terminal split for `tmc login` |
 

--- a/lua/tmc_plugin/api.lua
+++ b/lua/tmc_plugin/api.lua
@@ -310,6 +310,7 @@ local function detect_exercise()
     local rest = path:sub(#base + 2)
     local course_name, exercise_name = rest:match("^([^/\\]+)[/\\]([^/\\]+)")
     if not course_name or not exercise_name then return nil end
+
     for _, c in ipairs(_course_cache) do
         if c.name == course_name then
             for i, ex in ipairs(c.raw_exercises) do
@@ -323,7 +324,8 @@ local function detect_exercise()
                      index = nil, exercises = c.raw_exercises }
         end
     end
-    return nil  -- course not in cache at all
+    -- Course not in cache at all, but we DO know the identifiers
+    return { course = course_name, name = exercise_name }
 end
 
 -- Find the first source file inside <exercise_dir>/src/ (recursive).
@@ -380,6 +382,16 @@ local function navigate_to_exercise(ctx, target_ex)
     end
 
     open_exercise()
+end
+
+-- Open instructions for the current exercise
+function M.instructions()
+    local ctx = detect_exercise()
+    if not ctx or not ctx.name then
+        ui.notify("Not in a TMC exercise directory — open an exercise file first", "warn")
+        return
+    end
+    require("tmc_plugin.instructions").fetch_and_show(ctx.name)
 end
 
 -- Navigate to the exercise at (current_index + direction) in the course list.

--- a/lua/tmc_plugin/init.lua
+++ b/lua/tmc_plugin/init.lua
@@ -15,6 +15,7 @@ function M.setup(opts)
         TmcTest      = "test",
         TmcSubmit    = "submit",
         TmcDoctor    = "doctor",
+        TmcInstructions = "instructions",
         TmcLogin     = "login",
         TmcNext      = "next",
         TmcPrev      = "prev",

--- a/lua/tmc_plugin/instructions.lua
+++ b/lua/tmc_plugin/instructions.lua
@@ -1,0 +1,226 @@
+local M = {}
+local ui = require("tmc_plugin.ui")
+
+-- HTML to Markdown super-simple converter
+local function html_to_md(html)
+    if not html then return "" end
+    
+    local md = html
+    -- Remove span tags but keep content
+    md = string.gsub(md, "<span[^>]*>", "")
+    md = string.gsub(md, "</span%s*>", "")
+    
+    -- Links
+    md = string.gsub(md, '<a[^>]*href="([^"]+)"[^>]*>(.-)</a>', "[%2](%1)")
+    
+    -- Bold & Italic
+    md = string.gsub(md, "<strong[^>]*>(.-)</strong>", "**%1**")
+    md = string.gsub(md, "<b[^>]*>(.-)</b>", "**%1**")
+    md = string.gsub(md, "<em[^>]*>(.-)</em>", "*%1*")
+    
+    -- Code blocks: <div class="gatsby-highlight" data-language="python"><pre...><code...>...</code></pre></div>
+    md = string.gsub(md, '<div class="gatsby%-highlight"[^>]*data%-language="([^"]+)"[^>]*>.*<code[^>]*>(.-)</code>.*</div>', "\n```%1\n%2\n```\n")
+    
+    -- Inline code
+    md = string.gsub(md, "<code[^>]*>(.-)</code>", "`%1`")
+    
+    -- Sample output
+    md = string.gsub(md, "<sample%-output[^>]*>(.-)</sample%-output>", function(inner)
+        -- Inner might have <p> and \n. Clean it up for a blockquote style
+        inner = string.gsub(inner, "<p[^>]*>", "")
+        inner = string.gsub(inner, "</p>", "")
+        -- Add "> " to each line
+        local quoted = "\n"
+        for line in string.gmatch(inner .. "\n", "(.-)\n") do
+            if line ~= "" then
+                quoted = quoted .. "> " .. line .. "\n"
+            end
+        end
+        return "\n**Sample output**" .. quoted .. "\n"
+    end)
+    
+    -- Paragraphs
+    md = string.gsub(md, "<p[^>]*>(.-)</p>", "%1\n\n")
+    
+    -- Line breaks
+    md = string.gsub(md, "<br%s*/?>", "\n")
+    md = string.gsub(md, "</p>", "\n\n")
+    md = string.gsub(md, "</div>", "\n")
+    
+    -- Lists
+    md = string.gsub(md, "<ul[^>]*>(.-)</ul>", "%1")
+    md = string.gsub(md, "<li[^>]*>(.-)</li>", "- %1\n")
+    
+    -- Remove remaining HTML tags
+    md = string.gsub(md, "<[^>]+>", "")
+    
+    -- Unescape HTML entities
+    md = string.gsub(md, "&quot;", '"')
+    md = string.gsub(md, "&amp;", "&")
+    md = string.gsub(md, "&lt;", "<")
+    md = string.gsub(md, "&gt;", ">")
+    md = string.gsub(md, "&#39;", "'")
+    
+    -- Clean up extra newlines
+    md = string.gsub(md, "\n\n\n+", "\n\n")
+    return vim.trim(md)
+end
+
+local function get_cache_dir()
+    local dir = vim.fn.stdpath("cache") .. "/tmc_plugin/instructions"
+    if vim.fn.isdirectory(dir) == 0 then
+        vim.fn.mkdir(dir, "p")
+    end
+    return dir
+end
+
+-- Sync fetch with curl
+local function curl_json(url)
+    local obj = vim.system({"curl", "-sL", url}):wait()
+    if obj.code == 0 and obj.stdout then
+        local ok, data = pcall(vim.json.decode, obj.stdout)
+        if ok then return data end
+    end
+    return nil
+end
+
+function M.fetch_and_show(tmcname)
+    local cache_file = get_cache_dir() .. "/" .. tmcname .. ".md"
+    
+    -- Check cache first
+    local f = io.open(cache_file, "r")
+    if f then
+        local content = f:read("*a")
+        f:close()
+        M.show_in_split(tmcname, content)
+        return
+    end
+
+    local part = string.match(tmcname, "^part(%d%d)")
+    if not part then
+        vim.notify("Could not determine course part from exercise name: " .. tmcname, vim.log.levels.WARN)
+        return
+    end
+    part = tonumber(part)
+    
+    local base_url = "https://programming-25.mooc.fi"
+    local part_url = string.format("%s/page-data/part-%d/page-data.json", base_url, part)
+    
+    -- Start async fetching and parsing
+    vim.notify("Fetching instructions for " .. tmcname .. "...", vim.log.levels.INFO)
+    vim.system({"curl", "-sL", part_url}, function(obj)
+        if obj.code ~= 0 then
+            vim.schedule(function() vim.notify("Failed to fetch course data for part " .. part, vim.log.levels.ERROR) end)
+            return
+        end
+        local ok, data = pcall(vim.json.decode, obj.stdout)
+        if not ok or not data or not data.result or not data.result.data or not data.result.data.allPages then
+            vim.schedule(function() vim.notify("Failed to parse course data.", vim.log.levels.ERROR) end)
+            return
+        end
+        
+        local paths = {}
+        local prefix = string.format("/part-%d/", part)
+        for _, edge in ipairs(data.result.data.allPages.edges) do
+            local path = edge.node.frontmatter.path
+            if path and string.sub(path, 1, #prefix) == prefix then
+                table.insert(paths, path)
+            end
+        end
+        
+        -- To avoid blocking Neovim completely, but also since curl waits inside lua async are weird,
+        -- we could fire off all fetches async. For simplicity and robustness, we do sequential sync fetches
+        -- inside a fast async coroutine or vim.schedule loop, or vim.system async chain.
+        -- Since we're in a vim.system callback already, blocking here isn't great. Let's use `curl` synchronously inside a system thread? No, `vim.system` callback is executed in Neovim's main loop via uv poll, wait, no, it's executed in main thread by default if not careful, actually `vim.system` callback runs in main loop.
+        -- We should wrap this in `coroutine` using `vim.schedule`? No, simpler to just run a background script if needed, or chain them.
+        
+        -- Since we are already async in Neovim, we can't easily wait. Let's chain vim.system calls.
+        local function check_next_path(index)
+            if index > #paths then
+                vim.schedule(function() vim.notify("Instructions for " .. tmcname .. " not found on MOOC.fi", vim.log.levels.WARN) end)
+                return
+            end
+            
+            local path = paths[index]
+            local page_url = string.format("%s/page-data%s/page-data.json", base_url, path)
+            
+            vim.system({"curl", "-sL", page_url}, function(p_obj)
+                local found = false
+                if p_obj.code == 0 then
+                    local p_ok, p_data = pcall(vim.json.decode, p_obj.stdout)
+                    if p_ok and p_data.result and p_data.result.data and p_data.result.data.page then
+                        local html = p_data.result.data.page.html
+                        if html then
+                            -- Parse all exercises in this page and cache them
+                            for _, tag in ipairs({"in%-browser%-programming%-exercise", "programming%-exercise"}) do
+                                for exercise_block in string.gmatch(html, "<" .. tag .. "(.-)</" .. tag .. ">") do
+                                    local ex_tmcname = string.match(exercise_block, 'tmcname=["\']([^"\']+)["\']')
+                                    local ex_name = string.match(exercise_block, 'name=["\']([^"\']+)["\']')
+                                    
+                                    if ex_tmcname then
+                                        local content = string.match(exercise_block, ">%s*(.*)$")
+                                        if content then
+                                            local md = string.format("# %s\n\n%s", ex_name or ex_tmcname, html_to_md(content))
+                                            local f_out = io.open(get_cache_dir() .. "/" .. ex_tmcname .. ".md", "w")
+                                            if f_out then
+                                                f_out:write(md)
+                                                f_out:close()
+                                            end
+                                            if ex_tmcname == tmcname then
+                                                found = true
+                                            end
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+                
+                if found then
+                    local fh = io.open(cache_file, "r")
+                    if fh then
+                        local content = fh:read("*a")
+                        fh:close()
+                        vim.schedule(function() M.show_in_split(tmcname, content) end)
+                        return
+                    end
+                end
+                
+                check_next_path(index + 1)
+            end)
+        end
+        
+        check_next_path(1)
+    end)
+end
+
+function M.show_in_split(tmcname, content)
+    -- Close existing instructions buffer if any
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.api.nvim_buf_get_name(buf):match("TMC_Instructions") then
+            vim.api.nvim_win_close(win, true)
+        end
+    end
+
+    -- Create vertical split
+    vim.cmd("vsplit")
+    local win = vim.api.nvim_get_current_win()
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_win_set_buf(win, buf)
+    
+    local lines = vim.split(content, "\n")
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    
+    vim.api.nvim_buf_set_name(buf, "TMC_Instructions_" .. tmcname)
+    vim.bo[buf].filetype = "markdown"
+    vim.bo[buf].readonly = true
+    vim.bo[buf].modifiable = false
+    vim.bo[buf].bufhidden = "wipe"
+    
+    -- Map q to close
+    vim.keymap.set("n", "q", ":q<CR>", { buffer = buf, silent = true, noremap = true })
+end
+
+return M

--- a/lua/tmc_plugin/menu.lua
+++ b/lua/tmc_plugin/menu.lua
@@ -6,7 +6,7 @@ local config  = require("tmc_plugin.config")
 local system  = require("tmc_plugin.system")
 local _menu_win = nil   -- tracks the single open menu window
 
-local W = 52  -- total window width including the two border chars
+local W = 58  -- total window width including the two border chars
 
 -- ─── Box drawing ─────────────────────────────────────────────────────────────
 
@@ -48,8 +48,9 @@ local ITEMS = {
     { type = "item",  icon = "↑",  label = "Submit",      desc = "Submit exercise to TMC",       action = "submit" },
     { type = "spacer" },
     { type = "group", label = "Account" },
-    { type = "item",  icon = "󰍋",  label = "Login",       desc = "Sign in to TMC",              action = "login" },
-    { type = "item",  icon = "✔",  label = "Doctor",      desc = "Check connection & auth",     action = "doctor" },
+    { type = "item",  icon = "󰍋",   label = "Login",         desc = "Sign in to TMC",              action = "login" },
+    { type = "item",  icon = "📖",   label = "Instructions",  desc = "Show exercise instructions",  action = "instructions" },
+    { type = "item",  icon = "✔",   label = "Doctor",        desc = "Check connection & auth",     action = "doctor" },
 }
 
 -- ─── Buffer content builder ───────────────────────────────────────────────────
@@ -91,8 +92,16 @@ local function build(auth_status, course)
             table.insert(lines, sep())
         elseif item.type == "item" then
             local line_idx = #lines
-            local content = string.format("     %s  %-11s %s",
-                item.icon, item.label, item.desc)
+
+            local label_len = vim.fn.strdisplaywidth(item.label)
+            local icon_len  = vim.fn.strdisplaywidth(item.icon)
+            
+            local icon_pad = string.rep(" ", math.max(1, 4 - icon_len))
+            local label_pad = string.rep(" ", math.max(1, 15 - label_len))
+            
+            local content = string.format("     %s%s%s%s %s",
+                item.icon, icon_pad, item.label, label_pad, item.desc)
+            
             table.insert(lines, box(content))
             table.insert(selectables, {
                 line     = line_idx,
@@ -106,14 +115,15 @@ local function build(auth_status, course)
 
     table.insert(lines, box(""))
     table.insert(lines, mid())
-    table.insert(lines, box("  j/k Navigate   Enter Select   q Close"))
+    table.insert(lines, box("  j/k Navigate          Enter Select           q Close  "))
     table.insert(lines, bot())
 
-    -- Return indicator so the caller can compute its byte range for highlighting
     return lines, selectables, group_lines, indicator
 end
 
--- ─── Open ─────────────────────────────────────────────────────────────────────
+M._test_build = build
+
+-- ─── UI rendering ─────────────────────────────────────────────────────────────
 
 function M.open()
     -- If a menu is already open, close it first (prevents stacking)


### PR DESCRIPTION
## Description
This PR introduces the `:TmcInstructions` command, enabling users to fetch, parse, and view exercise instructions directly from the MOOC.fi Gatsby JSON endpoints from entirely within Neovim.

## Changes:
1. **instructions.lua**: A robust system to intercept Gatsby `page-data.json` endpoints, extract `<programming-exercise>` or `<in-browser-programming-exercise>` tags, and format HTML components natively into Markdown via Lua string patterns.
2. **api.lua**: Integrated context-aware path tracking that recognizes the current exercise state without needing to open the dashboard first.
3. **menu.lua**: Updated UI rendering metrics logic (using `strdisplaywidth`) to perfectly align icons in the floating command palette.
4. **README.md**: Updated documentation specifying the new module and instructions API endpoints.