### PR TITLE
feat: move download functionality to menu, fix api parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ All commands are registered by `setup()`. If a command is not found, check that 
 |---|---|
 | `:TmcMenu` | Open the floating command palette (recommended entry point) |
 | `:TmcDashboard` | Open the course selector → exercise dashboard |
+| `:TmcDownload` | Download exercises for a specific course |
 | `:TmcTest` | Run `tmc test` in the current exercise directory |
 | `:TmcSubmit` | Submit the current exercise with a live log window |
 | `:TmcNext` | Navigate to the next exercise in the current course |
@@ -132,6 +133,7 @@ The recommended entry point. Opens a centered floating window:
 │  Exercises                                             │
 │  ────────────────────────────────────────────────────  │
 │        Dashboard       Browse & manage exercises      │
+│     ⬇   Download        Download course exercises      │
 │     ✓   Test            Run tests in current exercise  │
 │     ↑   Submit          Submit exercise to TMC         │
 │                                                        │
@@ -241,7 +243,7 @@ Checks 1 and 3 run async and update in-place when results arrive — the report 
  [x] part01-02_seven_brothers
  [ ] part01-03_row_your_boat
 
- [Enter] Open  [t] Test  [d] Download  [s] Submit  [r] Refresh  [q] Close
+ [Enter] Open  [t] Test  [s] Submit  [r] Refresh  [q] Close
 ```
 
 | Key | Action |
@@ -249,11 +251,10 @@ Checks 1 and 3 run async and update in-place when results arrive — the report 
 | `<Enter>` | Open the exercise source file in a new buffer |
 | `t` | Run `tmc test` on the exercise under the cursor |
 | `s` | Submit the exercise under the cursor |
-| `d` | Download the exercise under the cursor |
 | `r` | Force-refresh data from TMC servers |
 | `q` | Close the dashboard |
 
-Move the cursor to an exercise line before pressing `<Enter>`, `t`, `s`, or `d`.
+Move the cursor to an exercise line before pressing `<Enter>`, `t`, or `s`.
 
 ---
 

--- a/lua/tmc_plugin/dashboard.lua
+++ b/lua/tmc_plugin/dashboard.lua
@@ -263,7 +263,7 @@ function M.render(course_name, exercises)
     end
 
     table.insert(lines, "")
-    table.insert(lines, " [Enter] Open  [t] Test  [d] Download  [s] Submit  [r] Refresh  [q] Close")
+    table.insert(lines, " [Enter] Open  [t] Test  [s] Submit  [r] Refresh  [q] Close")
 
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
 
@@ -336,15 +336,7 @@ function M.setup_keymaps(buf)
         end
 
         if vim.fn.isdirectory(exercise_dir) == 0 then
-            -- Not downloaded — download then open
-            require("tmc_plugin.api").download_exercise(current_course, ex.name, function()
-                local src = find_src(exercise_dir)
-                if src then
-                    vim.schedule(function() open_in_prev_win(src) end)
-                else
-                    ui.notify("No source file found in " .. ex.name, "warn")
-                end
-            end)
+            ui.notify("Exercise not downloaded. Please download the course exercises first from the menu.", "warn")
             return
         end
 
@@ -361,15 +353,7 @@ function M.setup_keymaps(buf)
         dashboard_test(get_selected_exercise())
     end, opts)
 
-    -- [d] → download the exercise under the cursor
-    vim.keymap.set("n", "d", function()
-        local ex = get_selected_exercise()
-        if ex and current_course then
-            require("tmc_plugin.api").download_exercise(current_course, ex.name)
-        else
-            ui.notify("Place cursor on an exercise first", "warn")
-        end
-    end, opts)
+    -- removed [d] download keymap
 
     -- [s] → submit the exercise under the cursor
     vim.keymap.set("n", "s", function()

--- a/lua/tmc_plugin/init.lua
+++ b/lua/tmc_plugin/init.lua
@@ -20,6 +20,7 @@ function M.setup(opts)
         TmcSubmit    = "submit",
         TmcDoctor    = "doctor",
         TmcInstructions = "instructions",
+        TmcDownload  = "download_prompt",
         TmcLogin     = "login",
         TmcNext      = "next",
         TmcPrev      = "prev",

--- a/lua/tmc_plugin/menu.lua
+++ b/lua/tmc_plugin/menu.lua
@@ -44,6 +44,7 @@ end
 local ITEMS = {
     { type = "group", label = "Exercises" },
     { type = "item",  icon = "󰙨",  label = "Dashboard",  desc = "Browse & manage exercises",   action = "open_dashboard" },
+    { type = "item",  icon = "⬇",  label = "Download",   desc = "Download course exercises",    action = "download_prompt" },
     { type = "item",  icon = "✓",  label = "Test",        desc = "Run tests in current exercise", action = "test" },
     { type = "item",  icon = "↑",  label = "Submit",      desc = "Submit exercise to TMC",       action = "submit" },
     { type = "spacer" },


### PR DESCRIPTION
## What changed

- **Menu Download**: Added `⬇ Download` to the `:TmcMenu` and added a standalone `:TmcDownload` command. This opens a native course picker to download all exercises for a course.
- **Removed individual download**: Removed the `[d]` keymap from the dashboard. `tmc-cli-rust` natively downloads full courses, not individual exercises. Pressing `<Enter>` on an undownloaded exercise now advises the user to download the course from the menu.
- **Fixed download path**: Altered `api.lua` download execution path to target `config.exercises_dir` directly, preventing the double-nested folder issue (e.g. `programming-25/programming-25`).
- **Fixed exercise parsing**: `tmc exercises` now returns output formatted as `Not completed: part01-01...` & `Completed: ...` instead of checkboxes. `parse_exercises()` was updated to cleanly strip these prefixes so `<Enter>` properly reads the physical folder name.
- **README Updates**: Updated the command list and UI mockups to match the changes.