### PR TITLE
feat: visual system doctor and contextual file breadcrumbs

### DIFF
--- a/lua/tmc_plugin/doctor.lua
+++ b/lua/tmc_plugin/doctor.lua
@@ -5,12 +5,12 @@ local M      = {}
 local config = require("tmc_plugin.config")
 local system = require("tmc_plugin.system")
 
-local PASS = "  \u{2713}  "   -- ✓  (3-byte UTF-8 at byte offset 2)
-local FAIL = "  \u{2717}  "   -- ✗
-local WARN = "  ~  "
-local UNKN = "  ?  "
-local INFO = "       "        -- 7 spaces (aligns with PASS text)
-local SEP  = "  " .. string.rep("\u{2500}", 54)  -- ─────
+local PASS = "    󰄬  "
+local FAIL = "    󰄱  "
+local WARN = "    ~  "
+local UNKN = "    ?  "
+local INFO = "       "
+local SEP  = "  ────────────────────────────────────────────────────────"
 
 -- ─── Sync checks ─────────────────────────────────────────────────────────────
 
@@ -152,63 +152,84 @@ end
 -- ─── Render ───────────────────────────────────────────────────────────────────
 
 function M.run()
-    local title    = "TMC Doctor \u{2014} " .. os.date("%Y-%m-%d %H:%M")
-    -- Async sections need fixed placeholder line counts matching max result lines
-    local BIN_PH  = { WARN .. "Checking...", "" }   -- Binary:  2 lines
-    local AUTH_PH = { WARN .. "Checking..." }        -- Auth:    1 line
+    local title    = "🏥 TMC System Health Report"
+    local BIN_PH  = { WARN .. "Checking...", "" }
+    local AUTH_PH = { WARN .. "Checking..." }
 
-    local buf_lines  = { title, string.rep("=", vim.api.nvim_strwidth(title)), "" }
-    local async_info = {}   -- [section_num] = { start, count }
+    local buf_lines = {
+        "  ╭────────────────────────────────────────────────────────╮",
+        "  │  " .. title .. string.rep(" ", 54 - vim.api.nvim_strwidth(title)) .. "│",
+        "  ╰────────────────────────────────────────────────────────╯",
+        ""
+    }
+    local async_info = {}
 
     local function add_section(num, label, result_lines)
-        table.insert(buf_lines, ("  [%d] %s"):format(num, label))
+        table.insert(buf_lines, "  " .. label)
         table.insert(buf_lines, SEP)
-        local start = #buf_lines   -- 0-based index of first result line
+        local start = #buf_lines
         for _, l in ipairs(result_lines) do table.insert(buf_lines, l) end
         async_info[num] = { start = start, count = #result_lines }
         table.insert(buf_lines, "")
     end
 
-    add_section(1, "Binary",             BIN_PH)
-    add_section(2, "Neovim",             chk_neovim())
-    add_section(3, "Authentication",     AUTH_PH)
-    add_section(4, "Exercises Directory",chk_exercises_dir())
-    add_section(5, "Cache",              chk_cache())
-    add_section(6, "Current Context",    chk_context())
-    add_section(7, "Configuration",      chk_config())
+    add_section(1, "System & Binaries", BIN_PH)
+    add_section(2, "Neovim", chk_neovim())
+    add_section(3, "Authentication", AUTH_PH)
+    add_section(4, "Exercises Directory", chk_exercises_dir())
+    add_section(5, "Cache", chk_cache())
+    add_section(6, "Current Context", chk_context())
+    add_section(7, "Configuration", chk_config())
+    
+    table.insert(buf_lines, "  [q] Close")
 
-    -- Create buffer
     local buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, buf_lines)
-    vim.bo[buf].modifiable = false; vim.bo[buf].buftype  = "nofile"
-    vim.bo[buf].bufhidden  = "wipe"; vim.bo[buf].swapfile = false
+    vim.bo[buf].modifiable = false
+    vim.bo[buf].buftype = "nofile"
+    vim.bo[buf].bufhidden = "wipe"
 
-    vim.cmd("botright 20split")
-    local win = vim.api.nvim_get_current_win()
-    vim.api.nvim_win_set_buf(win, buf)
-    for k, v in pairs({ wrap = false, number = false, relativenumber = false,
-                         signcolumn = "no", cursorline = false }) do
-        vim.wo[win][k] = v
-    end
-    vim.keymap.set("n", "q", ":close<CR>", { buffer = buf, silent = true })
+    -- Highlight setup
+    vim.api.nvim_set_hl(0, "TmcDocTitle", { fg = "#e5c07b", bold = true, default = true })
+    vim.api.nvim_set_hl(0, "TmcDocItem", { fg = "#abb2bf", default = true })
+    vim.api.nvim_set_hl(0, "TmcDocPass", { fg = "#98c379", bold = true, default = true })
+    vim.api.nvim_set_hl(0, "TmcDocWarn", { fg = "#e06c75", bold = true, default = true })
 
-    -- Highlights
+    local width = 60
+    local height = #buf_lines + 2
+    local ui = vim.api.nvim_list_uis()[1]
+    
+    local win = vim.api.nvim_open_win(buf, true, {
+        relative = "editor",
+        width = width,
+        height = height,
+        col = math.floor((ui.width - width) / 2),
+        row = math.floor((ui.height - height) / 2),
+        style = "minimal",
+        border = "rounded"
+    })
+
+    vim.keymap.set("n", "q", function() pcall(vim.api.nvim_win_close, win, true) end, { buffer = buf, silent = true })
+
     local ns = vim.api.nvim_create_namespace("tmc_doctor")
     local function apply_hl()
         vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
-        vim.api.nvim_buf_add_highlight(buf, ns, "TmcMenuTitle", 0, 0, -1)
+        vim.api.nvim_buf_add_highlight(buf, ns, "TmcDocTitle", 1, 0, -1)
         for i, l in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
             local li = i - 1
-            if     l:match("^  %[%d%]")   then vim.api.nvim_buf_add_highlight(buf, ns, "TmcMenuGroup", li, 0, -1)
-            elseif l:match("^  \u{2713}") then vim.api.nvim_buf_add_highlight(buf, ns, "TmcSuccess",   li, 2, 5)
-            elseif l:match("^  \u{2717}") then vim.api.nvim_buf_add_highlight(buf, ns, "TmcFailure",   li, 2, 5)
-            elseif l:match("^  [~?]")     then vim.api.nvim_buf_add_highlight(buf, ns, "TmcMenuHint",  li, 2, 3)
+            if l:match("───") then
+                vim.api.nvim_buf_add_highlight(buf, ns, "TmcDocItem", li, 0, -1)
+            elseif l:match("󰄬") then
+                local s = l:find("󰄬")
+                if s then vim.api.nvim_buf_add_highlight(buf, ns, "TmcDocPass", li, s - 1, s + 3) end
+            elseif l:match("󰄱") or l:match("~") or l:match("%?") then
+                local s = l:find("󰄱") or l:find("~") or l:find("%?")
+                if s then vim.api.nvim_buf_add_highlight(buf, ns, "TmcDocWarn", li, s - 1, s + 3) end
             end
         end
     end
     apply_hl()
 
-    -- Async updater — pads/trims to original placeholder count so line numbers stay stable
     local function update(num, new_lines)
         vim.schedule(function()
             if not vim.api.nvim_buf_is_valid(buf) then return end
@@ -223,7 +244,7 @@ function M.run()
     end
 
     chk_binary_async(function(l) update(1, l) end)
-    chk_auth_async(  function(l) update(3, l) end)
+    chk_auth_async(function(l) update(3, l) end)
 end
 
 return M

--- a/lua/tmc_plugin/init.lua
+++ b/lua/tmc_plugin/init.lua
@@ -1,6 +1,44 @@
 local M = {}
 local config = require("tmc_plugin.config")
 
+local function setup_breadcrumbs()
+    if vim.fn.has("nvim-0.8") == 0 then return end
+    vim.api.nvim_set_hl(0, "TmcBreadcrumbRoot", { fg = "#cba6f7", bold = true, default = true })
+    vim.api.nvim_set_hl(0, "TmcBreadcrumbSep", { fg = "#6c7086", default = true })
+    vim.api.nvim_set_hl(0, "TmcBreadcrumbCourse", { fg = "#89b4fa", default = true })
+    vim.api.nvim_set_hl(0, "TmcBreadcrumbExercise", { fg = "#f9e2af", italic = true, default = true })
+
+    vim.api.nvim_create_autocmd("BufEnter", {
+        group = vim.api.nvim_create_augroup("TmcBreadcrumbs", { clear = true }),
+        callback = function(args)
+            if vim.bo[args.buf].buftype ~= "" then return end
+            -- Ensure safe scheduling for UI updates
+            vim.schedule(function()
+                if not vim.api.nvim_buf_is_valid(args.buf) then return end
+                local path = vim.api.nvim_buf_get_name(args.buf)
+                local base = vim.fn.expand(config.exercises_dir)
+                if path:sub(1, #base) == base then
+                    local rest = path:sub(#base + 2)
+                    local course, exercise = rest:match("^([^/\\]+)[/\\]([^/\\]+)")
+                    if course and exercise then
+                        local c_name = course:gsub("-", " "):gsub("^%l", string.upper)
+                        local e_name = exercise:gsub("^[%w]+%-[%w]+_", ""):gsub("_", " ")
+                        if #e_name > 0 then e_name = e_name:sub(1,1):upper() .. e_name:sub(2) else e_name = exercise end
+                        
+                        local part = exercise:match("^([^%-]+)")
+                        local part_num = part and part:match("%d+")
+                        local section = part_num and ("Part " .. tonumber(part_num) .. " - ") or ""
+                        
+                        local winbar_str = "  %#TmcBreadcrumbRoot#󰮫 TMC%* %#TmcBreadcrumbSep#  %* %#TmcBreadcrumbCourse#" .. c_name .. "%* %#TmcBreadcrumbSep#  %* %#TmcBreadcrumbExercise#" .. section .. e_name .. "%*"
+                        
+                        pcall(function() vim.wo.winbar = winbar_str end)
+                    end
+                end
+            end)
+        end
+    })
+end
+
 function M.setup(opts)
     opts = opts or {}
     config.bin = opts.bin or "tmc"
@@ -34,6 +72,8 @@ function M.setup(opts)
             end
         end, { desc = "TMC: " .. api_func })
     end
+    
+    setup_breadcrumbs()
 end
 
 return M


### PR DESCRIPTION
## What changed

- **Visual System Health**: Revamped `:TmcDoctor` completely. It now renders as a sleek, centered floating Modal rather than a raw terminal dump. It uses explicit grouped layouts, colored Nerd-font icons (`✓/✗`), and dedicated syntax highlighting groups to clearly communicate the technical health of the plugin ecosystem.
- **Contextual File Breadcrumbs**: Hooked into Neovim's `BufEnter` via an `augroup` to detect files physically residing in the TMC Rust CLI downloads folder. Automatically computes the parent course name and exercise name strings and dynamically injects a beautiful `winbar` breadcrumb mapping path to the top of your editor frame so you always know where you are.